### PR TITLE
Update tool.sh for 1.10.x

### DIFF
--- a/assemble/bin/tool.sh
+++ b/assemble/bin/tool.sh
@@ -38,7 +38,7 @@ fi
 
 ZOOKEEPER_CMD='ls -1 $ZOOKEEPER_HOME/lib/zookeeper-[0-9]*[^csn].jar '
 ZOOKEEPER_VERSION=$(find -L "$ZOOKEEPER_HOME" -maxdepth 2 -name "zookeeper-[0-9]*.jar" | head -1)
-if [[ $ZOOKEEPER_VERSION =~ ^3[.][01234].*$ ]]; then
+if [[ $ZOOKEEPER_VERSION =~ .*-3[.][01234].*$ ]]; then
   ZOOKEEPER_CMD='ls -1 $ZOOKEEPER_HOME/zookeeper-[0-9]*[^csn].jar '
 fi
 if [[ $(eval $ZOOKEEPER_CMD | wc -l) -ne 1 ]] ; then


### PR DESCRIPTION
Modify the regex to successfully determine zookeeper version in the tool.sh script. 
Replacing  _^3[.][01234].*$_   with _.\*-3[.][01234].*$_